### PR TITLE
Prevent vlc from displaying filename when playing.

### DIFF
--- a/media_player_vlc.py
+++ b/media_player_vlc.py
@@ -99,7 +99,7 @@ class media_player_vlc(item.item, generic_response.generic_response):
 		self.event_handler_trigger = "on keypress"
 		self.vlc_event_handler = None
 
-		self.vlcInstance = vlc.Instance()
+		self.vlcInstance = vlc.Instance("--no-video-title-show")
 		self.player = self.vlcInstance.media_player_new()
 		self.media = None
 		self.framerate = 0


### PR DESCRIPTION
I haven't been able to test this, but it looks like a simple fix--a user here reports that this change addresses issue (1) from http://forum.cogsci.nl/index.php?p=/discussion/348/open-video-playback-questions/p1.
